### PR TITLE
allow matching of terms with spaces

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -42,7 +42,8 @@
       var name = $btn.getAttribute('data-icon');
       var icon = icons[name];
       var iconText = name + icon.alias.join('');
-      var matches = iconText.toLowerCase().indexOf(e.target.value.toLowerCase()) > -1;
+      var terms = e.target.value.toLowerCase().split(' ');
+      var matches = terms.reduce((acc, term) => acc && iconText.toLowerCase().includes(term), true);
       if (matches) {
         $btn.classList.remove('hide');
       } else {


### PR DESCRIPTION
Took Paul's solution from this [PR in Meridian](https://github.com/ArcGIS/calcite-meridian-icons/pull/24) and brought it in here. Works like a charm.